### PR TITLE
rename query dirs query-<md5> to query_<md5>

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ nqdc download -f query.txt nqdc_data
 After running this command, these are the contents of our data directory:
 ```
 · nqdc_data
-  └── query-3c0556e22a59e7d200f00ac8219dfd6c
+  └── query_3c0556e22a59e7d200f00ac8219dfd6c
       └── articlesets
           ├── articleset_00000.xml
           └── info.json
@@ -151,7 +151,7 @@ After running this command, these are the contents of our data directory:
 for the same query, the same subdirectory will be reused
 (`3c0556e22a59e7d200f00ac8219dfd6c` is the md5 checksum of the query). If we had
 used a PMCID list instead of a query, the subdirectory name would start with
-`pmcidList-` instead of `query-`.
+`pmcidList_` instead of `query_`.
 
 Inside the query directory, the results of the bulk download are stored in the
 `articlesets` directory. The articles themselves are in XML files bundling up to
@@ -183,7 +183,7 @@ separate directory. To do so, we pass the `articlesets` directory created by the
 `nqdc download` command in step 1:
 
 ```
-nqdc extract_articles nqdc_data/query-3c0556e22a59e7d200f00ac8219dfd6c/articlesets
+nqdc extract_articles nqdc_data/query_3c0556e22a59e7d200f00ac8219dfd6c/articlesets
 ```
 
 This creates an `articles` subdirectory in the query directory, containing the
@@ -198,7 +198,7 @@ conciseness):
 
 ```
 · nqdc_data
-  └── query-3c0556e22a59e7d200f00ac8219dfd6c
+  └── query_3c0556e22a59e7d200f00ac8219dfd6c
       ├── articles
       │   ├── 019
       │   │   └── pmcid_6759467
@@ -255,14 +255,14 @@ We pass the path of the `articles` directory created by `nqdc extract_articles`
 in the previous step to the `nqdc extract_data` command:
 
 ```
-nqdc extract_data --articles_with_coords_only nqdc_data/query-3c0556e22a59e7d200f00ac8219dfd6c/articles/
+nqdc extract_data --articles_with_coords_only nqdc_data/query_3c0556e22a59e7d200f00ac8219dfd6c/articles/
 ```
 
 Our data directory now contains (ommitting the contents of the previous steps):
 
 ```
 · nqdc_data
-  └── query-3c0556e22a59e7d200f00ac8219dfd6c
+  └── query_3c0556e22a59e7d200f00ac8219dfd6c
       ├── articles
       ├── articlesets
       └── subset_articlesWithCoords_extractedData
@@ -340,7 +340,7 @@ vectorize, created by `nqdc extract_data` in step 3 (here we are using the
 default vocabulary):
 
 ```
-nqdc vectorize nqdc_data/query-3c0556e22a59e7d200f00ac8219dfd6c/subset_articlesWithCoords_extractedData/
+nqdc vectorize nqdc_data/query_3c0556e22a59e7d200f00ac8219dfd6c/subset_articlesWithCoords_extractedData/
 ```
 
 This creates a new directory whose name reflects the data source (whether all
@@ -351,7 +351,7 @@ vocabulary file, concatenated with those of the vocabulary mapping file, see
 
 ```
 · nqdc_data
-  └── query-3c0556e22a59e7d200f00ac8219dfd6c
+  └── query_3c0556e22a59e7d200f00ac8219dfd6c
       ├── articles
       ├── articlesets
       ├── subset_articlesWithCoords_extractedData
@@ -436,7 +436,7 @@ It builds a vocabulary of all the words and 2-grams (groups of 2
 words) that appear in the downloaded text, and computes their document frequency
 (the proportion of documents in which a term appears).
 ```
-nqdc extract_vocabulary nqdc_data/query-3c0556e22a59e7d200f00ac8219dfd6c/subset_articlesWithCoords_extractedData
+nqdc extract_vocabulary nqdc_data/query_3c0556e22a59e7d200f00ac8219dfd6c/subset_articlesWithCoords_extractedData
 ```
 
 The vocabulary is stored in a csv file in a new directory. There is no header
@@ -444,7 +444,7 @@ and the 2 columns are the term and its document frequency.
 
 ```
 · nqdc_data
-  └── query-3c0556e22a59e7d200f00ac8219dfd6c
+  └── query_3c0556e22a59e7d200f00ac8219dfd6c
       ├── articles
       ├── articlesets
       ├── subset_articlesWithCoords_extractedData
@@ -477,14 +477,14 @@ Note: for this model to give good results a large dataset is needed, ideally clo
 
 We pass the `_vectorizedText` directory created by `nqdc vectorize`:
 ```
-nqdc fit_neuroquery nqdc_data/query-3c0556e22a59e7d200f00ac8219dfd6c/subset_articlesWithCoords-voc_e6f7a7e9c6ebc4fb81118ccabfee8bd7_vectorizedText
+nqdc fit_neuroquery nqdc_data/query_3c0556e22a59e7d200f00ac8219dfd6c/subset_articlesWithCoords-voc_e6f7a7e9c6ebc4fb81118ccabfee8bd7_vectorizedText
 ```
 
 This creates a directory whose name ends with `_neuroqueryModel`:
 
 ```
 · nqdc_data
-  └── query-3c0556e22a59e7d200f00ac8219dfd6c
+  └── query_3c0556e22a59e7d200f00ac8219dfd6c
       ├── articles
       ├── articlesets
       ├── subset_articlesWithCoords_extractedData
@@ -547,14 +547,14 @@ information.
 
 We pass the `_vectorizedText` directory created by `nqdc vectorize`:
 ```
-nqdc fit_neurosynth nqdc_data/query-3c0556e22a59e7d200f00ac8219dfd6c/subset_articlesWithCoords-voc_e6f7a7e9c6ebc4fb81118ccabfee8bd7_vectorizedText
+nqdc fit_neurosynth nqdc_data/query_3c0556e22a59e7d200f00ac8219dfd6c/subset_articlesWithCoords-voc_e6f7a7e9c6ebc4fb81118ccabfee8bd7_vectorizedText
 ```
 
 This creates a directory whose name ends with `_neurosynthResults`:
 
 ```
 · nqdc_data
-  └── query-3c0556e22a59e7d200f00ac8219dfd6c
+  └── query_3c0556e22a59e7d200f00ac8219dfd6c
       ├── articles
       ├── articlesets
       ├── subset_articlesWithCoords_extractedData
@@ -598,14 +598,14 @@ It prepares the articles whose data was extracted for annotation with
 We pass the `_extractedData` directory created by `nqdc extract_data`:
 
 ```
-nqdc extract_labelbuddy_data nqdc_data/query-3c0556e22a59e7d200f00ac8219dfd6c/subset_articlesWithCoords_extractedData
+nqdc extract_labelbuddy_data nqdc_data/query_3c0556e22a59e7d200f00ac8219dfd6c/subset_articlesWithCoords_extractedData
 ```
 
 This creates a directory whose name ends with `labelbuddyData` containing the batches of documents in JSONL format (in this case there is a single batch):
 
 ```
 · nqdc_data
-  └── query-3c0556e22a59e7d200f00ac8219dfd6c
+  └── query_3c0556e22a59e7d200f00ac8219dfd6c
       ├── articles
       ├── articlesets
       ├── subset_articlesWithCoords_extractedData
@@ -639,14 +639,14 @@ for details.
 We pass the `_vectorizedText` directory created by `nqdc vectorize`:
 
 ```
-nqdc extract_nimare_data nqdc_data/query-3c0556e22a59e7d200f00ac8219dfd6c/subset_articlesWithCoords-voc_e6f7a7e9c6ebc4fb81118ccabfee8bd7_vectorizedText
+nqdc extract_nimare_data nqdc_data/query_3c0556e22a59e7d200f00ac8219dfd6c/subset_articlesWithCoords-voc_e6f7a7e9c6ebc4fb81118ccabfee8bd7_vectorizedText
 ```
 
 The resulting directory contains a `nimare_dataset.json` file that can be used to initialize a `nimare.Dataset`. 
 
 ```
 · nqdc_data
-  └── query-3c0556e22a59e7d200f00ac8219dfd6c
+  └── query_3c0556e22a59e7d200f00ac8219dfd6c
       ├── articles
       ├── articlesets
       ├── subset_articlesWithCoords_extractedData

--- a/docs/example_plugin/tests/run_plugin.py
+++ b/docs/example_plugin/tests/run_plugin.py
@@ -19,7 +19,7 @@ with tempfile.TemporaryDirectory(suffix="_nqdc") as tmp_dir:
     assert (
         Path(tmp_dir)
         .joinpath(
-            "query-49e0abb9869a532a31d37ed788c76780",
+            "query_49e0abb9869a532a31d37ed788c76780",
             "subset_allArticles_examplePluginPubDatesPlot",
             "plot.png",
         )

--- a/src/nqdc/_download.py
+++ b/src/nqdc/_download.py
@@ -176,7 +176,7 @@ class _QueryDownloader(_Downloader):
 
     def _output_dir_name(self) -> str:
         """Directory name containing the checksum of the query string."""
-        return f"query-{_utils.checksum(self._query)}"
+        return f"query_{_utils.checksum(self._query)}"
 
     def _prepare_webenv(self, client: EntrezClient) -> Dict[str, str]:
         """Use ESearch to build the result set."""
@@ -220,7 +220,7 @@ class _PMCIDListDownloader(_Downloader):
         checksum = _utils.checksum(
             b",".join([str(pmcid).encode("UTF-8") for pmcid in self._pmcids])
         )
-        return f"pmcidList-{checksum}"
+        return f"pmcidList_{checksum}"
 
     def _prepare_webenv(self, client: EntrezClient) -> Dict[str, str]:
         """Use EPost to upload PMCIDs to the history server."""

--- a/tests/compare_query_vs_pmcid_list.py
+++ b/tests/compare_query_vs_pmcid_list.py
@@ -18,7 +18,7 @@ with tempfile.TemporaryDirectory("_nqdc_test") as tmp_dir:
     ]
     subprocess.run(nqdc_args, check=True)
     metadata_file = data_dir.joinpath(
-        "query-d3b30e14cf943416f1129eb1f111e8bc",
+        "query_d3b30e14cf943416f1129eb1f111e8bc",
         "subset_allArticles_extractedData",
         "metadata.csv",
     )
@@ -36,7 +36,7 @@ with tempfile.TemporaryDirectory("_nqdc_test") as tmp_dir:
     ]
     subprocess.run(new_nqdc_args, check=True)
     new_metadata_file = data_dir.joinpath(
-        "pmcidList-0594dba48803670013a89c740bf50934",
+        "pmcidList_0594dba48803670013a89c740bf50934",
         "subset_allArticles_extractedData",
         "metadata.csv",
     )

--- a/tests/run_full_pipeline.py
+++ b/tests/run_full_pipeline.py
@@ -45,7 +45,7 @@ def run_and_check():
 
     print("\n")
 
-    query_dir = data_dir.joinpath("query-1856490e8aca377ff8e6c38e84a77112")
+    query_dir = data_dir.joinpath("query_1856490e8aca377ff8e6c38e84a77112")
     vectorized_dir = list(
         query_dir.glob("subset_allArticles-voc_*_vectorizedText")
     )[0]

--- a/tests/test_articles.py
+++ b/tests/test_articles.py
@@ -46,7 +46,7 @@ def test_extract_articles(n_jobs, tmp_path, entrez_mock, monkeypatch):
     info_file.write_text(json.dumps(info), "utf-8")
     created_dir, code = _articles.extract_articles(download_dir)
     assert created_dir == tmp_path.joinpath(
-        "query-7838640309244685021f9954f8aa25fc", "articles"
+        "query_7838640309244685021f9954f8aa25fc", "articles"
     )
     assert code == ExitCode.INCOMPLETE
     info_file.unlink()

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -33,7 +33,7 @@ def test_full_pipeline_command_with_nimare(
     voc_file = test_data_dir.joinpath("vocabulary.csv")
     voc_checksum = _vectorization._checksum_vocabulary(voc_file)
     nimare_file = tmp_path.joinpath(
-        "query-7838640309244685021f9954f8aa25fc",
+        "query_7838640309244685021f9954f8aa25fc",
         f"subset_allArticles-voc_{voc_checksum}_nimareDataset",
         "nimare_dataset.json",
     )
@@ -108,7 +108,7 @@ def test_full_pipeline_command(
         assert voc_source == "default"
     code = _commands.nqdc_command(args)
     assert code == 0
-    query_name = "query-7838640309244685021f9954f8aa25fc"
+    query_name = "query_7838640309244685021f9954f8aa25fc"
     if voc_source == "extract":
         voc_file = tmp_path.joinpath(
             query_name,
@@ -154,7 +154,7 @@ def _check_download_query_file_output(tmp_path):
     query_file = tmp_path.joinpath("query")
     query_file.write_text("fMRI[abstract]", "utf-8")
     _commands.nqdc_command(["download", str(tmp_path), "-f", str(query_file)])
-    query_dir = tmp_path.joinpath("query-7838640309244685021f9954f8aa25fc")
+    query_dir = tmp_path.joinpath("query_7838640309244685021f9954f8aa25fc")
     articlesets_dir = query_dir.joinpath("articlesets")
     assert len(list(articlesets_dir.glob("*.xml"))) == 1
     return articlesets_dir
@@ -166,7 +166,7 @@ def _check_download_pmcid_list_output(tmp_path):
     _commands.nqdc_command(
         ["download", str(tmp_path), "--pmcids_file", str(pmcids_file)]
     )
-    query_dir = tmp_path.joinpath("pmcidList-94281be5de7c35a42f8abaf41d934ace")
+    query_dir = tmp_path.joinpath("pmcidList_94281be5de7c35a42f8abaf41d934ace")
     articlesets_dir = query_dir.joinpath("articlesets")
     assert len(list(articlesets_dir.glob("*.xml"))) == 1
     return articlesets_dir

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -15,7 +15,7 @@ def test_download_query_results(tmp_path, entrez_mock, monkeypatch):
     )
     assert code == ExitCode.ERROR
     assert download_dir == tmp_path.joinpath(
-        "query-7838640309244685021f9954f8aa25fc", "articlesets"
+        "query_7838640309244685021f9954f8aa25fc", "articlesets"
     )
     assert download_dir.joinpath("articleset_00000.xml").is_file()
     assert not download_dir.joinpath("articleset_00001.xml").is_file()
@@ -55,7 +55,7 @@ def test_download_pmcids(tmp_path, entrez_mock):
     download_dir, code = _download.download_pmcids([1, 2, 3], tmp_path)
     assert code == ExitCode.COMPLETED
     assert download_dir == tmp_path.joinpath(
-        "pmcidList-55b84a9d317184fe61224bfb4a060fb0", "articlesets"
+        "pmcidList_55b84a9d317184fe61224bfb4a060fb0", "articlesets"
     )
     assert (
         download_dir.joinpath("requested_pmcids.txt").read_text("UTF-8")

--- a/tests/test_labelbuddy.py
+++ b/tests/test_labelbuddy.py
@@ -34,7 +34,7 @@ def test_make_labelbuddy_documents(
     monkeypatch.setattr(_labelbuddy, "_CHAPTER_SIZE", 2)
     monkeypatch.setattr(_labelbuddy, "_LOG_PERIOD", 2)
     download_dir, _ = _download.download_query_results(
-        "fMRI[abstract]", tmp_path.joinpath("query-abc")
+        "fMRI[abstract]", tmp_path.joinpath("query_abc")
     )
     articles_dir, _ = _articles.extract_articles(download_dir)
     data_dir, _ = _data_extraction.extract_data_to_csv(articles_dir)

--- a/whats_new.md
+++ b/whats_new.md
@@ -2,6 +2,7 @@
 
 ## 0.0.3.dev
 
+- query output directories renamed from query-<md5> to query_<md5> to follow a bids-like convention.
 - It is now possible to download an explicit list of PMCIDs rather than a PMC query to select the articles to download.
   See the `--pmcids_file` parameter or the "Usage/Step 1" part of the documentation.
 - Articles in `query_dir/articles` are now each stored in a separate subdirectory; that also contains a `tables` subdirectory with the tables extracted from the article.


### PR DESCRIPTION
to be more consistent with other dirs names and bids-like convention